### PR TITLE
Fix(android): Resolve startup crash 

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     // Tambahkan dependensi untuk MediaPipe Vision Task
-    implementation("com.google.mediapipe:tasks-vision:latest.release")
+    implementation("com.google.mediapipe:tasks-vision:0.10.9")
 }
 
 flutter {

--- a/android/app/src/main/kotlin/com/example/mediapipe_native_test/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mediapipe_native_test/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.example.mediapipe_native_test
 
 import android.graphics.BitmapFactory
-import android.net.Uri
+import android.util.Log
 import androidx.annotation.NonNull
 import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.google.mediapipe.tasks.core.BaseOptions
@@ -12,37 +12,56 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 class MainActivity : FlutterActivity()
 {
     private val CHANNEL = "com.example.mediapipe_native_test/mediapipe"
     private var faceDetector: FaceDetector? = null
+    private lateinit var backgroundExecutor: ExecutorService
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        // Setup MediaPipe Face Detector
-        setupFaceDetector()
+        // Initialize a background executor
+        backgroundExecutor = Executors.newSingleThreadExecutor()
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
-            if (call.method == "detectFaces") {
-                val imagePath = call.argument<String>("imagePath")
-                if (imagePath == null) {
-                    result.error("INVALID_ARGUMENT", "Image path is null", null)
-                    return@setMethodCallHandler
-                }
+        // Offload the setup to a background thread
+        backgroundExecutor.execute {
+            try {
+                setupFaceDetector()
 
-                // Panggil fungsi deteksi
-                val detectionResult = detectFaces(imagePath)
-                if (detectionResult != null) {
-                    val faceCount = detectionResult.detections().size
-                    result.success(faceCount)
-                } else {
-                    result.error("DETECTION_FAILED", "MediaPipe Face Detector failed.", null)
+                // Setup MethodChannel only after the detector is initialized
+                runOnUiThread {
+                    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+                        if (call.method == "detectFaces") {
+                            val imagePath = call.argument<String>("imagePath")
+                            if (imagePath == null) {
+                                result.error("INVALID_ARGUMENT", "Image path is null", null)
+                                return@setMethodCallHandler
+                            }
+
+                            // The detection itself should also be offloaded
+                            backgroundExecutor.execute {
+                                val detectionResult = detectFaces(imagePath)
+                                runOnUiThread {
+                                    if (detectionResult != null) {
+                                        val faceCount = detectionResult.detections().size
+                                        result.success(faceCount)
+                                    } else {
+                                        result.error("DETECTION_FAILED", "MediaPipe Face Detector failed to detect faces.", null)
+                                    }
+                                }
+                            }
+                        } else {
+                            result.notImplemented()
+                        }
+                    }
                 }
-            } else {
-                result.notImplemented()
+            } catch (e: Exception) {
+                Log.e("MediaPipe", "Error setting up Face Detector: ${e.message}")
+                // Optionally, you can communicate this error back to Flutter
             }
         }
     }
@@ -59,22 +78,40 @@ class MainActivity : FlutterActivity()
                 .setRunningMode(RunningMode.IMAGE)
 
         val options = optionsBuilder.build()
+        // This can throw an exception if the model file is not found
         faceDetector = FaceDetector.createFromOptions(context, options)
     }
 
     private fun detectFaces(imagePath: String): FaceDetectorResult? {
-        val file = File(imagePath)
-        if (!file.exists()) {
+        if (faceDetector == null) {
+            Log.e("MediaPipe", "Face detector is not initialized.")
             return null
         }
 
-        // Buat bitmap dari path file
-        val bitmap = BitmapFactory.decodeFile(file.absolutePath)
+        val file = File(imagePath)
+        if (!file.exists()) {
+            Log.e("MediaPipe", "Image file not found at path: $imagePath")
+            return null
+        }
 
-        // Konversi bitmap ke MPImage
-        val mpImage = BitmapImageBuilder(bitmap).build()
+        return try {
+            // Create bitmap from path file
+            val bitmap = BitmapFactory.decodeFile(file.absolutePath)
 
-        // Jalankan deteksi
-        return faceDetector?.detect(mpImage)
+            // Convert bitmap to MPImage
+            val mpImage = BitmapImageBuilder(bitmap).build()
+
+            // Run detection
+            faceDetector?.detect(mpImage)
+        } catch (e: Exception) {
+            Log.e("MediaPipe", "Error during face detection: ${e.message}")
+            null
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Shut down the executor service
+        backgroundExecutor.shutdown()
     }
 }


### PR DESCRIPTION
The application was crashing on startup due to performing a long-running, blocking MediaPipe FaceDetector initialization on the main thread.

This commit fixes the issue by:
1.  Moving the `FaceDetector.createFromOptions` call to a background thread using an `ExecutorService`.
2.  Ensuring the `MethodChannel` is only set up after successful initialization.
3.  Moving the face detection logic itself to a background thread to prevent UI blocking.
4.  Pinning the `com.google.mediapipe:tasks-vision` dependency to a stable version (`0.10.9`) instead of `latest.release` to ensure build stability.